### PR TITLE
Calcular origem para as sprites animadas

### DIFF
--- a/TP Tank Game/TP Tank Game/Animated Sprite.cs
+++ b/TP Tank Game/TP Tank Game/Animated Sprite.cs
@@ -27,7 +27,7 @@ namespace TP_Tank_Game
             this.pixelSize.Y = this.pixelSize.Y / nrows;
 
             this.size = new Vector2(1f, (float)pixelSize.Y / (float)pixelSize.X);
-
+            this.origem = this.pixelSize * 0.5f;
             this.currentFrame = Point.Zero;
             Loop = true;
         }

--- a/TP Tank Game/TP Tank Game/Game1.cs
+++ b/TP Tank Game/TP Tank Game/Game1.cs
@@ -6,7 +6,6 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Storage;
-using Microsoft.Xna.Framework.GamerServices;
 #endregion
 
 namespace TP_Tank_Game


### PR DESCRIPTION
Estava a ser calculada a origem por omissao (no codigo da sprite) que
era a largura da imagem / 2 e altura da imagem / 2. No caso das sprites
animadas, temos de dividir o tamanho de CADA sprite, e nao da imagem
completa.
